### PR TITLE
Fix installation on 32bit platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ include_dirs = [p.join(CLD2_PATH, 'internal'), p.join(CLD2_PATH, 'public')]
 
 module = Extension('pycld2._pycld2',
                    language='c++',
-                   extra_compile_args=['-w', '-O2', '-m64', '-fPIC'],
+                   extra_compile_args=['-w', '-O2', '-fPIC'],
                    include_dirs=include_dirs,
                    libraries = [],
                    sources=src_files,


### PR DESCRIPTION
Installation on 32bit Ubuntu raise compilation exception:

```
In file included from /usr/include/python3.6m/Python.h:8:0,
                     from bindings/pycldmodule.cc:15:
    /usr/include/python3.6m/pyconfig.h:3:12: fatal error: x86_64-linux-gnu/python3.6m/pyconfig.h: No such file or directory
     #  include <x86_64-linux-gnu/python3.6m/pyconfig.h>
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    compilation terminated.
    error: command 'i686-linux-gnu-gcc' failed with exit status 1

    ----------------------------------------
Command "/home/quick/webapps/citaty/venv_citaty/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-79cyfho9/pycld2/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-v_8ewo75-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/quick/webapps/citaty/venv_citaty/include/site/python3.6/pycld2" failed with error code 1 in /tmp/pip-build-79cyfho9/pycld2/
```

It is reported  #30. After removing "-m64" argument from setup.py, compilation finished successfuly.