### PR TITLE
Fix compilation on macOS 10.15 + conda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 import io
 import re
 from os import path
+import platform
 
 import setuptools
 
@@ -66,16 +67,23 @@ for i in src_files:
 
 include_dirs = [path.join(CLD2_PATH, "internal"), path.join(CLD2_PATH, "public")]
 
-module = setuptools.Extension(
-    # First arg (name) is the full name of the extension, including
-    # any packages - ie. not a filename or pathname, but Python dotted
-    # name.
-    "pycld2._pycld2",
+kwargs = dict(
     sources=src_files,
     include_dirs=include_dirs,
     language="c++",
     # TODO: -m64 may break 32 bit builds
     extra_compile_args=["-w", "-O2", "-m64", "-fPIC"],
+)
+if platform.system() == "Darwin":
+    kwargs["extra_compile_args"] += ["-stdlib=libc++"]
+    kwargs["extra_link_args"] = ["-stdlib=libc++"]
+
+module = setuptools.Extension(
+    # First arg (name) is the full name of the extension, including
+    # any packages - ie. not a filename or pathname, but Python dotted
+    # name.
+    "pycld2._pycld2",
+    **kwargs
 )
 
 # We define version as PYCLD2_VERSION in the C++ module.


### PR DESCRIPTION
When Python comes from conda on macOS, we need to pass `-stdlib=libc++` to clang. This is precisely what https://github.com/bsolomon1124/pycld3/commit/ebca462e5ec6021f903a3d4c75dca437f5fc07fb does, for example, but many projects had to do it too, see https://github.com/spotify/annoy/pull/362/commits/5989d91ad1f53312a3b09fcbbf6a2d25034b868f for another example.

Without this fix, pycld2 does not compile on my macOS 10.15 machine.

Thanks!