### PR TITLE
Use github action to automate wheel builds for all platforms

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -1,0 +1,87 @@
+name: Python Package
+on: [push]
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+
+    name: Test ${{ matrix.os }} Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build module
+        run: |
+          python setup.py build_ext -i
+      - name: Run tests
+        run: |
+          python test_pycld2.py
+
+  build-wheels:
+    needs: [tests]
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    name: Build wheels for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip setuptools wheel cibuildwheel
+    - name: Build wheels
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+    - uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: ./wheelhouse/*.whl
+
+  build-sdist:
+    needs: [tests]
+
+    name: Build sdist
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip setuptools wheel
+    - name: Build wheels
+      run: |
+        python setup.py sdist
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz
+
+  upload-pypi:
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE
 

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,9 @@
 import io
 import re
 from os import path
+import platform
 
 import setuptools
-
-HERE = path.abspath(path.dirname(__file__))
-CLD2_PATH = path.join(HERE, "cld2")
-BIND_PATH = path.join(HERE, "bindings")
-
 
 # See internal/compile_libs.sh for some detail.  Note that this is *not*
 # simply internal/*.cc.  Issue #23: keep these relative for manifest.
@@ -57,14 +53,17 @@ src_files = [
         "utf8statetable.cc",
     )
 ]
-src_files.extend(
-    ["bindings/pycldmodule.cc", "bindings/encodings.cc"]
-)
+src_files.extend(["bindings/pycldmodule.cc", "bindings/encodings.cc"])
 for i in src_files:
     if not path.exists(i):
         raise RuntimeError("Missing source file: %s" % i)
 
-include_dirs = [path.join(CLD2_PATH, "internal"), path.join(CLD2_PATH, "public")]
+include_dirs = ["cld2/internal", "cld2/public"]
+
+if platform.system() == "Windows":
+    extra_compile_args = ["/O2"]
+else:
+    extra_compile_args = ["-w", "-O2", "-fPIC"]
 
 module = setuptools.Extension(
     # First arg (name) is the full name of the extension, including
@@ -74,17 +73,18 @@ module = setuptools.Extension(
     sources=src_files,
     include_dirs=include_dirs,
     language="c++",
-    # TODO: -m64 may break 32 bit builds
-    extra_compile_args=["-w", "-O2", "-m64", "-fPIC"],
+    extra_compile_args=extra_compile_args,
 )
 
 # We define version as PYCLD2_VERSION in the C++ module.
 # Note: we could also use `define_macros` arg to setup()
-VERSION = re.search(
-    r'^#define\s+PYCLD2_VERSION\s+"([^"]+)"$',
-    io.open(path.join(BIND_PATH, "pycldmodule.cc"), encoding="utf-8").read(),
-    re.M,
-).group(1)
+with io.open("bindings/pycldmodule.cc", encoding="utf-8") as fr:
+    VERSION = re.search(
+        r'^#define\s+PYCLD2_VERSION\s+"([^"]+)"$', fr.read(), re.M
+    ).group(1)
+
+with io.open("README.md", encoding="utf-8") as fr:
+    long_description = fr.read()
 
 if __name__ == "__main__":
     setuptools.setup(
@@ -95,10 +95,7 @@ if __name__ == "__main__":
         maintainer="Brad Solomon",
         maintainer_email="brad.solomon.1124@gmail.com",
         description="Python bindings around Google Chromium's embedded compact language detection library (CLD2)",
-        long_description=io.open(
-            path.join(HERE, "README.md"),
-            encoding="utf-8"
-        ).read(),
+        long_description=long_description,
         long_description_content_type="text/markdown",
         license="Apache2",
         url="https://github.com/aboSamoor/pycld2",


### PR DESCRIPTION
- added github actions script to build wheels and upload to pypi
- make all paths in setup.py relative
- remove invalid `universal` instruction in setup.cfg