### PR TITLE
Fix for macos M series and for -Wc++11-narrowing issue 

### DIFF
--- a/bindings/pycldmodule.cc
+++ b/bindings/pycldmodule.cc
@@ -60,7 +60,6 @@ static PyObject *
 detect(PyObject *self, PyObject *args, PyObject *kwArgs)
 {
   const char *bytes;
-  int numBytes;
 
   CLD2::CLDHints cldHints;
   cldHints.tld_hint = 0;
@@ -89,10 +88,9 @@ detect(PyObject *self, PyObject *args, PyObject *kwArgs)
 
   if (!PyArg_ParseTupleAndKeywords(args,
                                    kwArgs,
-                                   "s#|izzzziiiiiiii",
+                                   "s|izzzziiiiiiii",
                                    (char **) kwList,
                                    &bytes,
-                                   &numBytes,
                                    &isPlainText,
                                    &cldHints.tld_hint,
                                    &hintLanguage,
@@ -108,6 +106,7 @@ detect(PyObject *self, PyObject *args, PyObject *kwArgs)
                                    &flagBestEffort)) {
     return NULL;
   }
+  int numBytes = strlen(bytes);
 
   int flags = 0;
   if (flagScoreAsQuads != 0) {

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,13 @@ include_dirs = ["cld2/internal", "cld2/public"]
 if platform.system() == "Windows":
     extra_compile_args = ["/O2"]
 else:
-    extra_compile_args = ["-w", "-O2", "-fPIC"]
+    extra_compile_args = ["-w", "-O2", "-fPIC", "-Wno-narrowing"]
+
+compile_args = ["-w", "-O2", "-fPIC"]
+if platform.machine() == 'x86_64':
+    compile_args.append('-m64')
+elif platform.machine() == 'aarch64' or platform.machine() == 'arm64':
+    compile_args.append('-march=armv8-a')
 
 module = setuptools.Extension(
     # First arg (name) is the full name of the extension, including
@@ -112,6 +118,10 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            ""
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",
             "Topic :: Text Processing :: Linguistic",


### PR DESCRIPTION
This PR consists of two patches together and it can be replicated with the following
```shell
git clone https://github.com/aboSamoor/pycld2
cd pycld2
git checkout c71aa20a5cb04c93ac434abafea53bd570c9c1dc
# https://github.com/aboSamoor/pycld2/pull/44 - macos M chip series fix
wget https://patch-diff.githubusercontent.com/raw/aboSamoor/pycld2/pull/44.patch
patch -p1 < 44.patch
# https://github.com/aboSamoor/pycld2/pull/62 - narrowing flag fix
wget https://patch-diff.githubusercontent.com/raw/aboSamoor/pycld2/pull/62.patch
patch -p1 < 62.patch
cd ..
python -m venv env
source env/bin/activate
python -m pip install ./pycld2
python -c "import pycld2 as cld2; isReliable, textBytesFound, details = cld2.detect('Teď, dělej dělej! Dělej! Dělej! Dělej!'); print(details[0])"
# ('CZECH', 'cs', 97, 512.0)
```